### PR TITLE
Expand example for path_prefix and staging environment

### DIFF
--- a/examples/sinatra/README.md
+++ b/examples/sinatra/README.md
@@ -1,0 +1,28 @@
+# Sinatra example
+
+This example uses a path_prefix in a rackup configuration and illustrates how to configure a development example to work
+towards Fishbrain's Cognito staging environment.
+
+Start by installing the gems:
+
+`$ cd examples/sinatra && bundle`
+
+Then run the application with rackup:
+
+`$ FISHBRAIN_CLIENT_ID=<staging_client_id> FISHBRAIN_CLIENT_SECRET=<staging_client_secret> bundle exec rackup -p 3000`
+
+Alternatively, configure the app with this block:
+
+`use OmniAuth::Builder do
+     provider :fishbrain,
+              ENV.fetch('FISHBRAIN_CLIENT_ID'),
+              ENV.fetch('FISHBRAIN_CLIENT_SECRET'),
+              path_prefix: '/client/auth',
+              client_options: {
+                site: 'https://accounts-staging.fishbrain.com'
+              }
+   end` 
+   
+And run without rackup:
+
+`$ FISHBRAIN_CLIENT_ID=<staging_client_id> FISHBRAIN_CLIENT_SECRET=<staging_client_secret> PORT=3000 ruby fishbrain_example.rb`

--- a/examples/sinatra/config.ru
+++ b/examples/sinatra/config.ru
@@ -1,0 +1,9 @@
+require File.expand_path('fishbrain_example', File.dirname(__FILE__))
+
+use OmniAuth::Builder do
+  configure do |config|
+    config.path_prefix = '/client/auth'
+  end
+end
+
+run FishbrainExample

--- a/examples/sinatra/fishbrain_example.rb
+++ b/examples/sinatra/fishbrain_example.rb
@@ -6,6 +6,8 @@ require 'omniauth'
 require 'omniauth-fishbrain'
 require 'pp'
 
+
+
 # Example Sinatra+Omniauth+Fishbrain app
 class FishbrainExample < Sinatra::Application
   configure do
@@ -15,18 +17,21 @@ class FishbrainExample < Sinatra::Application
   use OmniAuth::Builder do
     provider :fishbrain,
              ENV.fetch('FISHBRAIN_CLIENT_ID'),
-             ENV.fetch('FISHBRAIN_CLIENT_SECRET')
+             ENV.fetch('FISHBRAIN_CLIENT_SECRET'),
+             client_options: {
+               site: 'https://accounts-staging.fishbrain.com'
+             }
   end
 
   get '/' do
     haml :index
   end
 
-  get '/auth/failure' do
+  get '/client/auth/failure' do
     haml :auth_failure
   end
 
-  get '/auth/:provider/callback' do
+  get '/client/auth/:provider/callback' do
     haml :callback
   end
 

--- a/examples/sinatra/views/index.haml
+++ b/examples/sinatra/views/index.haml
@@ -7,8 +7,5 @@
     %h1
       Welcome
 
-    %a{ href: "/auth/fishbrain" }
+    %a{ href: "/client/auth/fishbrain" }
       Log in with Fishbrain
-
-    %a{ href: "/auth/cognito-idp" }
-      Log in with Cognito


### PR DESCRIPTION
Adds a rackup configuration file to illustrate how to support a path_prefix and modifies sinatra app to use it with the staging environment