### PR TITLE
Don't verify aud

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 2.5
 
 Style/Documentation:
   Enabled: false

--- a/lib/omniauth-fishbrain/version.rb
+++ b/lib/omniauth-fishbrain/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module Fishbrain
-    VERSION = '0.11.4'
+    VERSION = '0.11.5'
   end
 end

--- a/lib/omniauth/fishbrain/decode_id_token.rb
+++ b/lib/omniauth/fishbrain/decode_id_token.rb
@@ -28,7 +28,7 @@ module OmniAuth
         {
           iss: iss,
           aud: client_id,
-          verify_aud: true,
+          verify_aud: false,
           verify_expiration: true,
           verify_iat: true,
           verify_iss: true,

--- a/omniauth-fishbrain.gemspec
+++ b/omniauth-fishbrain.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.email    = ['erik.dalen@fishbrain.com', 'developer@fishbrain.com']
   s.homepage = 'https://github.com/fishbrain/omniauth-fishbrain'
   s.files    = Dir['lib/**/*.rb', 'LICENSE', 'README.markdown']
+  s.required_ruby_version = '>= 2.5.0'
 
   s.add_runtime_dependency 'jwt', '~> 2.0'
   s.add_runtime_dependency 'omniauth-oauth2', '~> 1.6'


### PR DESCRIPTION
The token that gets passed to Marketplacer will most likely contain the `client_id` of the ios/android apps, not Marketplacer's `client_id`.

This is why Marketplacer, in their testing, are seeing:

```
OmniAuth::Fishbrain::DecodeIdToken.new("715cxxx", "eu-west-1_TKWveIcYu").decode("VALID_TOKEN")
> JWT::InvalidAudError: Invalid audience. Expected 715cxxx, received 5clixxx
```
Where "715cxxx" is the marketplace client_id and "5clixxx" is the ios client_id.

I have no idea if this PR opens us up to a security issue. 🤷 