### PR TITLE
FIB-22232 Add api_cache gem to cache requests for jwks.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ Gemfile.lock
 .byebug_history
 .env
 .idea
+.rbenv-gemsets
 
 *.gem

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. For info on how to format all future additions to this file please reference [Keep A Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.12.0] - 2021-08-12
+
+- Add caching of jwks.json
+
 ## [0.11.1] - 2020-03-27
 
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,5 @@ group :development, :test do
   gem 'rubocop'
   gem 'sinatra'
   gem 'timecop'
+  gem 'webmock'
 end

--- a/lib/omniauth-fishbrain.rb
+++ b/lib/omniauth-fishbrain.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'omniauth/fishbrain/jwks'
 require 'omniauth-fishbrain/version'
 require 'omniauth/strategies/fishbrain'
 require 'omniauth/strategies/fishbrain_id'

--- a/lib/omniauth-fishbrain/version.rb
+++ b/lib/omniauth-fishbrain/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module Fishbrain
-    VERSION = '0.11.5'
+    VERSION = '0.11.6'
   end
 end

--- a/lib/omniauth/fishbrain/decode_id_token.rb
+++ b/lib/omniauth/fishbrain/decode_id_token.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-require 'net/http'
+require 'omniauth/fishbrain/jwks'
 require 'jwt'
 
 module OmniAuth
   module Fishbrain
     class DecodeIdToken
+      include Jwks
+
       AWS_REGION = 'eu-west-1'
       USER_POOL_ID = 'eu-west-1_TKWveIcYu'
 
@@ -44,10 +46,7 @@ module OmniAuth
       end
 
       def jwks
-        @_jwks ||= "#{iss}/.well-known/jwks.json"
-          .yield_self(&URI.method(:parse))
-          .yield_self(&Net::HTTP.method(:get))
-          .yield_self { |it| JSON.parse(it, symbolize_names: true) }
+        get_json("#{iss}/.well-known/jwks.json")
       end
     end
   end

--- a/lib/omniauth/fishbrain/jwks.rb
+++ b/lib/omniauth/fishbrain/jwks.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'api_cache'
+
+module OmniAuth
+  module Fishbrain
+    module Jwks
+      def get_json(uri)
+        APICache.get('fishbrain_jwks', cache: 86_400) do # 24 hours
+          uri
+            .yield_self(&URI.method(:parse))
+            .yield_self(&Net::HTTP.method(:get))
+            .yield_self { |it| JSON.parse(it, symbolize_names: true) }
+        end
+      end
+    end
+  end
+end

--- a/lib/omniauth/fishbrain/verifies_id_token.rb
+++ b/lib/omniauth/fishbrain/verifies_id_token.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'net/http'
+require 'omniauth/fishbrain/jwks'
 require 'jwt'
 
 module OmniAuth
@@ -34,11 +34,7 @@ module OmniAuth
       end
 
       def jwks
-        @_jwks ||= \
-          "#{iss}/.well-known/jwks.json"
-            .yield_self(&URI.method(:parse))
-            .yield_self(&Net::HTTP.method(:get))
-            .yield_self { |it| JSON.parse(it, symbolize_names: true) }
+        get_json("#{iss}/.well-known/jwks.json")
       end
     end
   end

--- a/omniauth-fishbrain.gemspec
+++ b/omniauth-fishbrain.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.files    = Dir['lib/**/*.rb', 'LICENSE', 'README.markdown']
   s.required_ruby_version = '>= 2.5.0'
 
+  s.add_runtime_dependency 'api_cache', '~> 0.3.0'
   s.add_runtime_dependency 'jwt', '~> 2.0'
   s.add_runtime_dependency 'omniauth-oauth2', '~> 1.6'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'omniauth'
 require 'omniauth-fishbrain'
 require 'rack/test'
 require 'rspec'
+require 'webmock/rspec'
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods


### PR DESCRIPTION
Maybe an in-memory cache isn't the best/most reliable solution but at least it's agnostic to the environment it will be deployed into. More background in the Jira issue